### PR TITLE
💚 Rollback node CI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,10 @@ orbs:
 executors:
   node:
     docker:
-      - image: circleci/node
+      - image: circleci/node:16.13.0
   hasura:
     docker:
-      - image: circleci/node
+      - image: circleci/node:16.13.0
       - image: postgres:12
         name: postgres
         environment:


### PR DESCRIPTION
See https://github.com/webpack/webpack/issues/14532
Default `circle/node` image went to v17 and broke webpack, rolling back to `16.13`