### PR TITLE
🔒🚸 improve authentication

### DIFF
--- a/src/components/GraphQLProvider.tsx
+++ b/src/components/GraphQLProvider.tsx
@@ -30,6 +30,7 @@ const GraphQLProvider = ({ children }) => {
     loginWithRedirect,
     isAuthenticated,
     isLoading,
+    error,
   } = useAuth0();
   const [client, setClient] = useState<ApolloClient<any> | undefined>(
     undefined
@@ -38,8 +39,20 @@ const GraphQLProvider = ({ children }) => {
     if (isLoading) {
       return;
     }
+    if (error) {
+      if (error.message === "Login required") {
+        loginWithRedirect({
+          redirect_uri: NEXT_PUBLIC_BASE_URL,
+          prompt: "login",
+        });
+        return;
+      } else {
+        console.error(error);
+        return;
+      }
+    }
     if (!isAuthenticated) {
-      loginWithRedirect({ redirect_uri: NEXT_PUBLIC_BASE_URL });
+      loginWithRedirect({ redirect_uri: NEXT_PUBLIC_BASE_URL, prompt: "none" });
       return;
     }
     (async () => {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -64,6 +64,7 @@ const App = ({ Component, pageProps }) => {
       scope="read:current_user"
       redirectUri={BASE_URL}
       useRefreshTokens={true}
+      connection="google-oauth2"
     >
       <DarkModeProvider value={{ darkMode, changeDarkMode }}>
         <i18nContext.Provider value={{ t, changeLocale }}>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -64,7 +64,6 @@ const App = ({ Component, pageProps }) => {
       scope="read:current_user"
       redirectUri={BASE_URL}
       useRefreshTokens={true}
-      cacheLocation={"localstorage"}
     >
       <DarkModeProvider value={{ darkMode, changeDarkMode }}>
         <i18nContext.Provider value={{ t, changeLocale }}>


### PR DESCRIPTION
Includes 2 improvements
- 🔒 remove auth local storage cache
Caching tokens in local storage is not recommended. See https://auth0.com/docs/libraries/auth0-single-page-app-sdk#change-storage-options. I've replaced the cache by a silent authentication. The app tries a silent login first, and then if it is denied by Auth0, it falls back to the normal interactive login sequence.
- 🚸 go straight to google for login
Skip the Auth0 login prompt and go straight to Google when logging in, since this is the only connection available anyway.