### PR TITLE
🚑 fix login when consent is required

### DIFF
--- a/src/components/GraphQLProvider.tsx
+++ b/src/components/GraphQLProvider.tsx
@@ -40,7 +40,10 @@ const GraphQLProvider = ({ children }) => {
       return;
     }
     if (error) {
-      if (error.message === "Login required") {
+      if (
+        error.message === "Login required" ||
+        error.message === "Consent required"
+      ) {
         loginWithRedirect({
           redirect_uri: NEXT_PUBLIC_BASE_URL,
           prompt: "login",


### PR DESCRIPTION
Silent authentication falls back to classic authentication only when the error from the identity provider is "Login required", whereas it should do it also for "Consent required".