### PR TITLE
:bug: fix z-index when hovering circles and, fix text circle on homepage

### DIFF
--- a/src/components/HomePanel.tsx
+++ b/src/components/HomePanel.tsx
@@ -185,7 +185,7 @@ const HomePanel = ({
             </div>
           </div>
 
-          {isDesktop ? (
+          {isDesktop && (
             <div className={`flex flex-auto flex-col w-3/5 h-full`}>
               <Radar
                 x={x}
@@ -195,8 +195,6 @@ const HomePanel = ({
                 title={t(`home.${name}`)}
               />
             </div>
-          ) : (
-            <></>
           )}
         </div>
 

--- a/src/components/Radar.tsx
+++ b/src/components/Radar.tsx
@@ -15,7 +15,7 @@ const Circle = ({ data, color }: { data: RadarData; color: string }) => {
   const [isHovering, setIsHovering] = useState(false);
 
   const handleMouseOver = () => {
-    if (data.weight > 60) setIsHovering(true);
+    if (data.weight > 50) setIsHovering(true);
   };
 
   const handleMouseOut = () => {
@@ -29,6 +29,7 @@ const Circle = ({ data, color }: { data: RadarData; color: string }) => {
         left: `${data.x - (isHovering ? data.weight + 70 : 50) / 2}px`,
         width: `${isHovering ? data.weight + 70 : 50}px`,
         height: `${isHovering ? data.weight + 70 : 50}px`,
+        zIndex: `${isHovering ? "999" : "1"}`,
       }}
       onMouseOver={handleMouseOver}
       onMouseOut={handleMouseOut}
@@ -40,8 +41,8 @@ const Circle = ({ data, color }: { data: RadarData; color: string }) => {
             data.weight > 30 ? "p-4" : ""
           }`}
         >
-          {!isHovering && data.weight > 60 && `${data.labels.length}`}
-          {!isHovering && data.weight < 60 && data.labels.join(", ")}
+          {!isHovering && data.weight > 50 && `+${data.labels.length}`}
+          {!isHovering && data.weight < 50 && data.labels.join(", ")}
           {isHovering && data.labels.join(", ")}
         </span>
       </div>
@@ -59,16 +60,10 @@ const RadarCell = ({
   const { t } = useContext(i18nContext);
   return (
     <div className="flex flex-col justify-between w-1/6 h-full border border-dashed border-opacity-25 border-light-radargrid dark:border-dark-radargrid">
-      {first && isFullSize ? (
+      {first && isFullSize && (
         <span className="rotated">{t("radar.desire")}</span>
-      ) : (
-        <></>
       )}
-      {first && isFullSize ? (
-        <span className="ml-2">{t("radar.level")}</span>
-      ) : (
-        <></>
-      )}
+      {first && isFullSize && <span className="ml-2">{t("radar.level")}</span>}
     </div>
   );
 };


### PR DESCRIPTION
Closes https://github.com/Zenika/skillZ/issues/233

For this issue, my fix is the following : 
- On homepage, when more than 3 skills are in the same circle, the text becomes the number of skills in this circle preceded by a + sign to avoid confusion with the skill number.
- It also impacts the text in all graph, all circles are preceded by a + sign.

<img width="1227" alt="image" src="https://user-images.githubusercontent.com/20949060/192299737-37afa85f-7fb3-4a6a-a353-57f7bdef3555.png">
