### PR TITLE
👷 Update CircleCI config.yml to use cimg/node:lts image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
       hasura-clever-app-id:
         type: string
     docker:
-      - image: circleci/node:lts
+      - image: cimg/node:lts
     steps:
       - checkout
       - run:
@@ -175,7 +175,7 @@ jobs:
           command: hasura-cli metadata apply --admin-secret << parameters.hasura-admin-secret >> --endpoint << parameters.hasura-endpoint >>
   deploy:
     docker:
-      - image: circleci/node:lts
+      - image: cimg/node:lts
     parameters:
       graphql-url:
         type: string


### PR DESCRIPTION
The deployment is blocked because it requires NodeJS >= 18. The latest circleci/node image installs node V16.

cimg/node images are designed to supercede the legacy CircleCI Node.js image, circleci/node.


